### PR TITLE
Add clarifications on 3-headed flail perk interactions.

### DIFF
--- a/mod_hardened/hooks/items/weapons/three_headed_flail.nut
+++ b/mod_hardened/hooks/items/weapons/three_headed_flail.nut
@@ -3,6 +3,8 @@
 	{
 		__original();
 
+		this.m.Description = "Three separate striking heads attached to a handle by chains.  Each head can hit or miss a target separately and strike over or around shield cover.  Perks that interact with attacks (like [Overwhelm|Perk+perk_overwhelm] and [Pattern Recognition|Perk+perk_pattern_recognition]) will only trigger once per attack, but perks that interact with hits (like [Wear Them Down|Perk+perk_wear_them_down], [Fearsome|Perk+perk_fearsome], [Double Strike|Perk+perk_double_strike], and [Headhunter|Perk+perk_headhunter]) will independently trigger on each hit (for better or for worse).";
+
 		this.m.Reach = 3;		// In Reforged this is 4
 	}
 });


### PR DESCRIPTION
I tried to test this, but when running

`zip -r /run/media/kovas/other/SteamLibrary/steamapps/common/Battle\ Brothers/data/mod_my_hardened.zip Hardened/*` (I'm on linux) and removing my normal hardened install, I did not see the updated description.  I also tried adding a new flail to my inventory via https://www.nexusmods.com/battlebrothers/mods/583?tab=description and still did not see the description.

Any idea what I might be missing here?  I'm also not sure if the perk links work in this context string or not, because my testing failed.